### PR TITLE
Add support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:8
+WORKDIR app
+ENV ARCHIVE_PATH /data
+CMD ["node", "index.js"]
+
+RUN chown -R node:node /app
+RUN mkdir /data
+RUN chown node:node /data
+
+USER node
+
+ADD --chown=node build .
+ADD --chown=node package.json  .
+ADD --chown=node melinda-ui-commons/package.json melinda-ui-commons/
+
+RUN npm install --production

--- a/server/index.js
+++ b/server/index.js
@@ -42,6 +42,10 @@ const PORT = readEnvironmentVariable('HTTP_PORT', 3001);
 
 const app = express();
 
+process.on('SIGINT', () => {
+  process.exit(-1);
+});
+
 app.use(expressWinston);
 app.use(cookieParser());
 
@@ -56,4 +60,3 @@ app.use(express.static(path.resolve(__dirname, 'public')));
 const server = app.listen(PORT, () => logger.log('info', `Application started on port ${PORT}`));
 
 server.timeout = 1800000; // Half an hour
-


### PR DESCRIPTION
Add support for Docker. Signal trapping for SIGINT is to allow terminating a foreground container with CTRL-C.